### PR TITLE
Update /boot/GENERIC if it exists

### DIFF
--- a/freebsd-update
+++ b/freebsd-update
@@ -1445,17 +1445,57 @@ fetch_filter_metadata () {
 	rm $1.tmp
 }
 
-# Filter the metadata file $1 by adding lines with "/boot/$2"
-# replaced by ${KERNELDIR} (which is `sysctl -n kern.bootfile` minus the
-# trailing "/kernel"); and if "/boot/$2" does not exist, remove
-# the original lines which start with that.
-# Put another way: Deal with the fact that the FOO kernel is sometimes
-# installed in /boot/FOO/ and is sometimes installed elsewhere.
+# Filter the metadata file $1 such that the running kernel is only
+# updated if it is GENERIC (i.e. $2 (which is ${KERNCONF}) is GENERIC).
+# If it is not GENERIC, but /boot/GENERIC exists, install kernel updates
+# into /boot/GENERIC (instead of /boot/kernel).
+# I do not see how $1 could ever contain anything else but /boot/kernel
+# for kernel related updates, or anything else than files relating to a
+# GENERIC kernel, but that might just be lack of understanding.
+# So there are two cases:
+# A) running kernel is GENERIC (i.e. ${KERNCONF} = GENERIC)
+#   -> install updates into the running kernel's dir (i.e. ${KERNELDIR})
+#   -> this means that '/boot/kernel' should be *replaced* by '${KERNELDIR}
+#      in $1 to handle cases where the running kernel is not in '/boot/kernel'
+#   -> ignore '/boot/GENERIC' on the system's disk if it exists, unless
+#      it is where the running kernel lives
+# B) running kernel is not GENERIC (i.e. ${KERNCONF} != GENERIC) but FOO
+#   -> do not touch the running kernel (i.e. do not install into ${KERNELDIR})
+#   -> if '/boot/GENERIC' exists, replace '/boot/kernel' with '/boot/GENERIC'
+#      in $1 (i.e. install the updated kernel into '/boot/GENERIC' instead
+#      of '/boot/kernel')
+#   -> if '/boot/FOO' (i.e. '/boot/${KERNCONF}' which is '/boot/$2') is
+#      listed in $1 (is that even possible?), *replace* '/boot/FOO' in $1
+#      with '/boot/${KERNELDIR}' (i.e. update the running kernel if its
+#      name (${KERNCONF}) suggests that $1 means to update it; do this
+#      without the requirement that the currently running kernel lives in
+#      '/boot/FOO')
+# TODO: verify that this also holds true for upgrades (minor and major).
 fetch_filter_kernel_names () {
-	grep ^/boot/$2 $1 |
-	    sed -e "s,/boot/$2,${KERNELDIR},g" |
-	    sort - $1 > $1.tmp
-	mv $1.tmp $1
+    if ! [ ${2} = "GENERIC" ]; then
+        # case B), we are currently NOT running a GENERIC kernel (i.e. we ARE
+        # running a custom kernel)
+        if [ -d "/boot/GENERIC" ]; then
+            # if '/boot/GENERIC' exists on disk, update it instead of
+            # '/boot/kernel'
+            sed -i "" -e "s,/boot/kernel,/boot/GENERIC,g" $1
+        fi
+        # now remove lines that would override the currently running kernel
+        # from $1
+		grep -v ^${KERNELDIR} $1 > $1.tmp
+		mv $1.tmp $1
+        # and change existing lines in $1 that want to update a kernel that
+        # has the same name as our running kernel
+        # (can this ever happen?)
+        sed -i "" -e "s,/boot/$2,${KERNELDIR},g" $1
+    else
+        # case A), we are currently running a GENERIC kernel
+        grep ^/boot/$2 $1 |
+            sed -e "s,/boot/$2,${KERNELDIR},g" |
+            sort - $1 > $1.tmp
+        mv $1.tmp $1
+        sed -i "" -e "s,/boot/kernel,${KERNELDIR},g" $1
+    fi
 
 	if ! [ -d /boot/$2 ]; then
 		grep -v ^/boot/$2 $1 > $1.tmp


### PR DESCRIPTION
The Handbook (https://www.freebsd.org/doc/handbook/updating-upgrading-freebsdupdate.html) suggests that freebsd-update keeps /boot/GENERIC up to date if it exists on systems running a custom kernel.

That does not seem to be true.
See
https://lists.freebsd.org/pipermail/freebsd-questions/2012-August/244210.html
https://lists.freebsd.org/pipermail/freebsd-questions/2013-April/250508.html
and others.

Because the behaviour described in the Handbook seems to make sense, this is an attempt to change freebsd-update to behave like the Handbook suggests.